### PR TITLE
arch-timer: fix a64_write_timer_cval() interface

### DIFF
--- a/drivers/arm/arch-timer.c
+++ b/drivers/arm/arch-timer.c
@@ -90,7 +90,7 @@ void a64_write_timer_tval(int timer, uint32_t tval)
 	}
 }
 
-void a64_write_timer_cval(int timer, uint32_t val)
+void a64_write_timer_cval(int timer, uint64_t val)
 {
 	switch (timer) {
 	case TIMER_PHYS:

--- a/drivers/arm/arch-timer.h
+++ b/drivers/arm/arch-timer.h
@@ -15,4 +15,4 @@ uint64_t a64_read_timer_cnt(int timer);
 uint32_t a64_read_timer_ctl(int timer);
 void a64_write_timer_ctl(int timer, uint32_t ctl);
 void a64_write_timer_tval(int timer, uint32_t tval);
-void a64_write_timer_cval(int timer, uint32_t val);
+void a64_write_timer_cval(int timer, uint64_t val);


### PR DESCRIPTION
CNTxx_CVAL_xx are 64bit registers. Stripping down a written
value to 32bit leads to unexpected timer interrupts when
the timer value exceeds 32bit.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>